### PR TITLE
Update Me page: add the ability to change password, display forms count  created by user and other

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -115,6 +115,10 @@ html {
   margin-bottom: 24px !important;
 }
 
+.input-item-text-link {
+  margin-bottom: 0 !important;
+}
+
 .ant-input::placeholder {
   font-size: 12px;
 }
@@ -123,4 +127,13 @@ html {
   .ant-input::placeholder {
     font-size: 14px;
   }
+}
+
+/* для сброса стилей автозаполнения браузера */
+.ant-input:-webkit-autofill,
+.ant-input-affix-wrapper:-webkit-autofill {
+  background-color: transparent !important;
+  -webkit-box-shadow: 0 0 0 1000px transparent inset !important;
+  -webkit-text-fill-color: var(--color-text) !important;
+  transition: background-color 5000s ease-in-out 0s !important;
 }

--- a/src/components/Auth/AuthSubmitButton.tsx
+++ b/src/components/Auth/AuthSubmitButton.tsx
@@ -9,7 +9,7 @@ type Props = {
 
 export const AuthSubmitButton = ({ children, disabled, loading }: Props) => {
   return (
-    <Form.Item>
+    <Form.Item className="input-item">
       <Button
         htmlType="submit"
         block

--- a/src/components/Auth/AuthTextLink.tsx
+++ b/src/components/Auth/AuthTextLink.tsx
@@ -9,7 +9,7 @@ type Props = {
 
 export const AuthTextLink = ({ text, linkText, linkTo }: Props) => {
   return (
-    <Form.Item className="text-center text-xs md:text-sm flex justify-end mb-0">
+    <Form.Item className="text-center text-xs md:text-sm flex justify-end mb-0 input-item-text-link">
       <span className="text-xs md:text-sm"> {text}&nbsp;</span>
       <Link to={linkTo} className="underline text-xs md:text-sm hover:underline font-medium">
         {linkText}

--- a/src/components/Auth/UserFormInput.tsx
+++ b/src/components/Auth/UserFormInput.tsx
@@ -6,6 +6,7 @@ type Props<T extends FieldValues> = {
   name: Path<T>;
   control: Control<T>;
   rules: RegisterOptions<T>;
+  disabled?: boolean;
   type?: 'text' | 'password';
   placeholder: 'Email' | 'Пароль' | 'Имя' | 'Фамилия' | 'Новый пароль' | 'Текущий пароль';
   prefix?: ReactNode;

--- a/src/components/Auth/UserFormInput.tsx
+++ b/src/components/Auth/UserFormInput.tsx
@@ -7,7 +7,7 @@ type Props<T extends FieldValues> = {
   control: Control<T>;
   rules: RegisterOptions<T>;
   type?: 'text' | 'password';
-  placeholder: 'Email' | 'Пароль' | 'Имя' | 'Фамилия';
+  placeholder: 'Email' | 'Пароль' | 'Имя' | 'Фамилия' | 'Новый пароль' | 'Текущий пароль';
   prefix?: ReactNode;
   suffix?: ReactNode;
   label?: string;

--- a/src/components/Me/MeAvatar.tsx
+++ b/src/components/Me/MeAvatar.tsx
@@ -1,20 +1,15 @@
-import { LoadingOutlined, PlusOutlined } from '@ant-design/icons';
-import { notification, Upload, UploadProps } from 'antd';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { Loader } from '../ui/Loader';
 
 type Props = {
   currentAvatarUrl?: string;
   isLoading: boolean;
-  isEdit: boolean;
   avatar: File | null;
   setAvatar: Dispatch<SetStateAction<File | null>>;
 };
 
-export const MeAvatar = ({ currentAvatarUrl, isLoading, isEdit, setAvatar, avatar }: Props) => {
-  const [loading, setLoading] = useState(false);
+export const MeAvatar = ({ currentAvatarUrl, isLoading, avatar }: Props) => {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
-  const [isHover, setHover] = useState<boolean>(false);
 
   useEffect(() => {
     if (avatar) {
@@ -26,66 +21,19 @@ export const MeAvatar = ({ currentAvatarUrl, isLoading, isEdit, setAvatar, avata
     }
   }, [avatar]);
 
-  const beforeUpload: UploadProps['beforeUpload'] = (file) => {
-    const isJpgOrPng =
-      file.type === 'image/jpeg' || file.type === 'image/png' || file.type === 'image/webp';
-    if (!isJpgOrPng) {
-      notification.error({
-        message: 'Ошибка',
-        description: 'Можно загружать только JPG/PNG/WEBP!',
-      });
-      return false;
-    }
-
-    const isLt2M = file.size / 1024 / 1024 < 8;
-    if (!isLt2M) {
-      notification.error({
-        message: 'Ошибка',
-        description: 'Файл должен быть меньше 8MB!',
-      });
-      return false;
-    }
-
-    setLoading(true);
-    setAvatar(file);
-    return false;
-  };
-
   const image = previewUrl
     ? previewUrl
     : currentAvatarUrl
       ? currentAvatarUrl
       : 'https://ui-avatars.com/api/?name=User&background=random';
 
-  const uploadButton = (
-    <button style={{ border: 0, background: 'none' }}>
-      {loading ? <LoadingOutlined /> : <PlusOutlined />}
-    </button>
-  );
-
   if (isLoading) return <Loader />;
 
   return (
-    <div className="flex justify-center w-full">
+    <div className="flex justify-center w-full mb-6">
       <div className="flex flex-col gap-4">
-        <div
-          className="relative w-36 h-36 rounded-full overflow-hidden shadow-xl"
-          onMouseEnter={() => setHover(true)}
-          onMouseLeave={() => setHover(false)}
-        >
+        <div className="relative w-36 h-36 rounded-full overflow-hidden shadow-xl">
           <img src={image} className="w-full h-full object-cover" alt="avatar" />
-          {isHover && isEdit && (
-            <div className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-50">
-              <Upload
-                name="avatar"
-                listType="picture-circle"
-                showUploadList={false}
-                beforeUpload={beforeUpload}
-              >
-                {uploadButton}
-              </Upload>
-            </div>
-          )}
         </div>
       </div>
     </div>

--- a/src/components/Me/MeChangePassword.tsx
+++ b/src/components/Me/MeChangePassword.tsx
@@ -1,0 +1,122 @@
+import { useUpdatePasswordMutation } from '@/redux/user';
+import { Form, Button, notification, Typography } from 'antd';
+import { useState } from 'react';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { MdOutlineCancel, MdVisibility, MdVisibilityOff } from 'react-icons/md';
+import { UserFormInput } from '../Auth/UserFormInput';
+import { UserFormValidationRules } from '@/utils/validation';
+import { RiLockFill } from 'react-icons/ri';
+import { ChangePasswordFormValues } from '@/types/me';
+
+export const MeChangePassword = () => {
+  const [isEdit, setEdit] = useState<boolean>(false);
+  const [showCurrentPassword, setShowCurrentPassword] = useState<boolean>(false);
+  const [showNewPassword, setShowNewPassword] = useState<boolean>(false);
+
+  const [updatePassword, { isLoading }] = useUpdatePasswordMutation();
+
+  const { control, handleSubmit, reset } = useForm<ChangePasswordFormValues>({
+    mode: 'onBlur',
+  });
+
+  const toggleCurrentPasswordVisibility = () => setShowCurrentPassword((prev) => !prev);
+  const toggleNewPasswordVisibility = () => setShowNewPassword((prev) => !prev);
+
+  const onSubmit: SubmitHandler<ChangePasswordFormValues> = async (data) => {
+    try {
+      await updatePassword(data).unwrap();
+      notification.success({ message: 'Пароль успешно обновлен' });
+      reset();
+    } catch (error) {
+      notification.error({
+        message: 'Пароль не обновлён. Убедитесь, что текущий пароль введён правильно.',
+      });
+      console.error('Ошибка изменения пароля:', error);
+    }
+  };
+
+  return (
+    <>
+      {isEdit ? (
+        <Form onFinish={handleSubmit(onSubmit)} layout="vertical" className="w-full">
+          <UserFormInput
+            control={control}
+            name="currentPassword"
+            type={showCurrentPassword ? 'text' : 'password'}
+            placeholder="Текущий пароль"
+            rules={UserFormValidationRules.password}
+            prefix={<RiLockFill size={20} className="mr-1" />}
+            suffix={
+              <span
+                onClick={toggleCurrentPasswordVisibility}
+                className="flex items-center justify-center cursor-pointer p-0 m-0 h-auto w-auto hover:text-gray-500"
+                aria-label={showCurrentPassword ? 'hideCurrentPassword' : 'showCurrentPassword'}
+              >
+                {showCurrentPassword ? <MdVisibilityOff size={20} /> : <MdVisibility size={20} />}
+              </span>
+            }
+          />
+          <UserFormInput
+            control={control}
+            name="newPassword"
+            type={showNewPassword ? 'text' : 'password'}
+            placeholder="Новый пароль"
+            rules={UserFormValidationRules.password}
+            prefix={<RiLockFill size={20} className="mr-1" />}
+            suffix={
+              <span
+                onClick={toggleNewPasswordVisibility}
+                className="flex items-center justify-center cursor-pointer p-0 m-0 h-auto w-auto hover:text-gray-500"
+                aria-label={showNewPassword ? 'hideNewPassword' : 'showNewPassword'}
+              >
+                {showNewPassword ? <MdVisibilityOff size={20} /> : <MdVisibility size={20} />}
+              </span>
+            }
+          />
+          <Form.Item>
+            <Button
+              type="primary"
+              style={{
+                height: '35.81px',
+              }}
+              htmlType="submit"
+              loading={isLoading}
+              block
+            >
+              Обновить пароль
+            </Button>
+          </Form.Item>
+          <Form.Item>
+            <Button
+              onClick={() => setEdit(!isEdit)}
+              color="danger"
+              variant="filled"
+              icon={<MdOutlineCancel size={15} />}
+              className="w-full"
+              style={{
+                height: '33.79px',
+              }}
+            >
+              Отменить
+            </Button>
+          </Form.Item>
+        </Form>
+      ) : (
+        <div
+          onClick={() => setEdit(!isEdit)}
+          className="flex justify-center items-center cursor-pointer"
+        >
+          <Typography.Title
+            level={5}
+            style={{
+              marginBottom: 0,
+            }}
+            className="hover:text-primary transition-all duration-300 ease-in-out"
+          >
+            Изменить пароль
+          </Typography.Title>
+        </div>
+      )}
+    </>
+  );
+};

--- a/src/components/Me/MeChangePassword.tsx
+++ b/src/components/Me/MeChangePassword.tsx
@@ -37,7 +37,21 @@ export const MeChangePassword = () => {
 
   return (
     <>
-      {isEdit ? (
+      <div
+        onClick={() => setEdit(!isEdit)}
+        className={`flex justify-center items-center cursor-pointer select-none ${isEdit && 'mb-6'}`}
+      >
+        <Typography.Title
+          level={5}
+          style={{
+            marginBottom: 0,
+          }}
+          className="hover:text-primary transition-all duration-300 ease-in-out"
+        >
+          Изменить пароль
+        </Typography.Title>
+      </div>
+      {isEdit && (
         <Form onFinish={handleSubmit(onSubmit)} layout="vertical" className="w-full">
           <UserFormInput
             control={control}
@@ -86,9 +100,12 @@ export const MeChangePassword = () => {
               Обновить пароль
             </Button>
           </Form.Item>
-          <Form.Item>
+          <Form.Item className="mb-0">
             <Button
-              onClick={() => setEdit(!isEdit)}
+              onClick={() => {
+                reset();
+                setEdit(!isEdit);
+              }}
               color="danger"
               variant="filled"
               icon={<MdOutlineCancel size={15} />}
@@ -101,21 +118,6 @@ export const MeChangePassword = () => {
             </Button>
           </Form.Item>
         </Form>
-      ) : (
-        <div
-          onClick={() => setEdit(!isEdit)}
-          className="flex justify-center items-center cursor-pointer"
-        >
-          <Typography.Title
-            level={5}
-            style={{
-              marginBottom: 0,
-            }}
-            className="hover:text-primary transition-all duration-300 ease-in-out"
-          >
-            Изменить пароль
-          </Typography.Title>
-        </div>
       )}
     </>
   );

--- a/src/components/Me/MeProfileActions.tsx
+++ b/src/components/Me/MeProfileActions.tsx
@@ -20,21 +20,22 @@ export const MeProfileActions = ({
   isUpdating,
   avatar,
 }: Props) => {
-  const btnPositionStyles = 'absolute top-4 right-5 p-0 m-0 bg-transparent border-none';
+  const btnPositionStyles =
+    'absolute top-4 right-5 p-0 m-0 bg-transparent border-none transition-all duration-300 ease-in-out';
   const submitBtnStyles = `${btnPositionStyles} ${
     !isValid || JSON.stringify(dirtyFields) === '{}'
       ? 'opacity-30 cursor-not-allowed'
-      : 'opacity-100 cursor-pointer'
+      : 'opacity-100 cursor-pointer hover:text-primary'
   }`;
   const isSubmitDisabled = !isValid || (JSON.stringify(dirtyFields) === '{}' && !avatar);
 
   return isEdit ? (
     <button type="submit" className={submitBtnStyles} disabled={isSubmitDisabled || isUpdating}>
-      <FaRegCheckCircle size={35} />
+      <FaRegCheckCircle size={30} />
     </button>
   ) : (
     <button className={btnPositionStyles} onClick={() => setEdit(true)}>
-      <MdEdit size={35} className="cursor-pointer" />
+      <MdEdit size={30} className="cursor-pointer hover:text-primary" />
     </button>
   );
 };

--- a/src/components/Me/MeProfileActions.tsx
+++ b/src/components/Me/MeProfileActions.tsx
@@ -1,4 +1,5 @@
 import { MeData } from '@/types/me';
+import { Spin } from 'antd';
 import { Dispatch, SetStateAction } from 'react';
 import { FaRegCheckCircle } from 'react-icons/fa';
 import { MdEdit } from 'react-icons/md';
@@ -29,8 +30,10 @@ export const MeProfileActions = ({
   }`;
   const isSubmitDisabled = !isValid || (JSON.stringify(dirtyFields) === '{}' && !avatar);
 
-  return isEdit ? (
-    <button type="submit" className={submitBtnStyles} disabled={isSubmitDisabled || isUpdating}>
+  return isUpdating ? (
+    <Spin size="large" className={btnPositionStyles} />
+  ) : isEdit ? (
+    <button type="submit" className={submitBtnStyles} disabled={isSubmitDisabled}>
       <FaRegCheckCircle size={30} />
     </button>
   ) : (

--- a/src/components/Me/MeProfileDetails.tsx
+++ b/src/components/Me/MeProfileDetails.tsx
@@ -14,17 +14,19 @@ type Props = {
   reset: UseFormReset<MeChangeFields>;
   user: MeData;
   setEdit: Dispatch<SetStateAction<boolean>>;
-  isEditing: boolean;
+  isEdit: boolean;
   setAvatar: Dispatch<SetStateAction<File | null>>;
+  isUpdating: boolean;
 };
 
 export const MeProfileDetails = ({
-  isEditing,
+  isEdit,
   control,
   reset,
   user,
   setEdit,
   setAvatar,
+  isUpdating,
 }: Props) => {
   const handleFormsReset = () => {
     reset({
@@ -43,7 +45,7 @@ export const MeProfileDetails = ({
       if (!isJpgOrPng) {
         notification.error({
           message: 'Ошибка',
-          description: 'Можно загружать только JPG/PNG/WEBP!',
+          description: 'Для аватара можно загружать только форматы JPG/PNG/WEBP!',
         });
         return;
       }
@@ -63,7 +65,7 @@ export const MeProfileDetails = ({
 
   return (
     <>
-      {!isEditing ? (
+      {!isEdit ? (
         <div className="flex flex-col items-start gap-2">
           <div className="flex flex-col items-start gap-2">
             <div className="flex gap-2 items-start justify-start">
@@ -96,12 +98,14 @@ export const MeProfileDetails = ({
             <Input
               type="file"
               accept="image/*"
+              disabled={isUpdating}
               onChange={handleFileChange}
               className="text-textPrimary file:cursor-pointer file:bg-transparent file:border-none file:text-textPrimary "
             />
           </div>
           <UserFormInput
             control={control}
+            disabled={isUpdating}
             label="Имя"
             name="firstName"
             placeholder="Имя"
@@ -109,6 +113,7 @@ export const MeProfileDetails = ({
           />
           <UserFormInput
             control={control}
+            disabled={isUpdating}
             name="lastName"
             placeholder="Фамилия"
             label="Фамилия"

--- a/src/components/Me/MeProfileDetails.tsx
+++ b/src/components/Me/MeProfileDetails.tsx
@@ -2,12 +2,12 @@ import { UserFormValidationRules } from '@/utils/validation';
 import { Control, UseFormReset } from 'react-hook-form';
 import { Dispatch, SetStateAction } from 'react';
 import { MeChangeFields, MeData } from '@/types/me';
-import { Button } from 'antd';
-import { MdOutlineCancel, MdOutlineEmail } from 'react-icons/md';
-import { FaRegRegistered } from 'react-icons/fa6';
+import { Button, Input, notification } from 'antd';
+import { MdOutlineCancel } from 'react-icons/md';
 import { formatUserCreatedAt } from '@/utils/formatUserCreatedAt';
-import { MdPerson } from 'react-icons/md';
 import { UserFormInput } from '../Auth/UserFormInput';
+import { MdOutlineDateRange, MdOutlineAlternateEmail } from 'react-icons/md';
+import { MdOutlineAssignment } from 'react-icons/md';
 
 type Props = {
   control: Control<any>;
@@ -30,34 +30,76 @@ export const MeProfileDetails = ({
     reset({
       firstName: user?.firstName || '',
       lastName: user?.lastName || '',
-      email: user?.email || '',
     });
     setAvatar(null);
     setEdit(false);
   };
 
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      const isJpgOrPng =
+        file.type === 'image/jpeg' || file.type === 'image/png' || file.type === 'image/webp';
+      if (!isJpgOrPng) {
+        notification.error({
+          message: 'Ошибка',
+          description: 'Можно загружать только JPG/PNG/WEBP!',
+        });
+        return;
+      }
+
+      const isLt8M = file.size / 1024 / 1024 < 8;
+      if (!isLt8M) {
+        notification.error({
+          message: 'Ошибка',
+          description: 'Файл должен быть меньше 8MB!',
+        });
+        return;
+      }
+
+      setAvatar(file);
+    }
+  };
+
   return (
     <>
-      <div className="text-base mb-4 font-medium">Информация о пользователе</div>
       {!isEditing ? (
         <div className="flex flex-col items-start gap-2">
-          <div className="flex gap-2 items-start justify-start mb-4">
-            <MdPerson size={20} />
-            <span className="w-full break-all text-left">
-              {`${user?.firstName} ${user?.lastName}`}
-            </span>
-          </div>
-          <div className="flex gap-2 items-start justify-start mb-4">
-            <MdOutlineEmail size={20} />
-            <span className="w-full break-all text-left">{user?.email}</span>
-          </div>
-          <div className="flex gap-2 items-start justify-start mb-4">
-            <FaRegRegistered size={20} />
-            {`Дата регистрации: ${formatUserCreatedAt(user?.createdAt)}`}
+          <div className="flex flex-col items-start gap-2">
+            <div className="flex gap-2 items-start justify-start">
+              <span className="w-full text-2xl font-bold text-left break-words">
+                {`${user?.firstName} ${user?.lastName}`}
+              </span>
+            </div>
+            <div className="flex gap-2 items-center justify-start">
+              <MdOutlineAlternateEmail size={20} />
+              <span className="w-full text-lg font-semibold text-left break-words">
+                {user?.email}
+              </span>
+            </div>
+            <div className="flex gap-2 items-start justify-start">
+              <MdOutlineAssignment size={20} />
+              <span className="w-full text-left">{`Количество созданных форм: ${user?.formsCount}`}</span>
+            </div>
+            <div className="flex gap-2 items-start justify-start">
+              <MdOutlineDateRange size={20} />
+              <span className="w-full text-left">{`Дата регистрации: ${formatUserCreatedAt(
+                user?.createdAt
+              )}`}</span>
+            </div>
           </div>
         </div>
       ) : (
         <div>
+          <div className="flex flex-col items-start mb-6">
+            <label className="ml-2">Аватар</label>
+            <Input
+              type="file"
+              accept="image/*"
+              onChange={handleFileChange}
+              className="text-textPrimary file:cursor-pointer file:bg-transparent file:border-none file:text-textPrimary "
+            />
+          </div>
           <UserFormInput
             control={control}
             label="Имя"
@@ -72,19 +114,33 @@ export const MeProfileDetails = ({
             label="Фамилия"
             rules={UserFormValidationRules.surname}
           />
-          <UserFormInput
-            control={control}
-            name="email"
-            label="Email"
-            placeholder="Email"
-            rules={UserFormValidationRules.email}
-          />
+          <div className="flex flex-col gap-5 mb-6">
+            <div className="flex gap-2 items-center justify-start">
+              <MdOutlineAlternateEmail size={20} />
+              <span className="w-full text-lg font-semibold text-left break-words">
+                {user?.email}
+              </span>
+            </div>
+            <div className="flex gap-2 items-start justify-start">
+              <MdOutlineAssignment size={20} />
+              <span className="w-full text-left">{`Количество созданных форм: ${user?.formsCount}`}</span>
+            </div>
+            <div className="flex gap-2 items-start justify-start">
+              <MdOutlineDateRange size={20} />
+              <span className="w-full text-left">{`Дата регистрации: ${formatUserCreatedAt(
+                user?.createdAt
+              )}`}</span>
+            </div>
+          </div>
           <Button
             onClick={handleFormsReset}
             color="danger"
             variant="filled"
             icon={<MdOutlineCancel size={15} />}
             className="w-full"
+            style={{
+              height: '33.79px',
+            }}
           >
             Отменить изменения
           </Button>

--- a/src/components/Me/MeProfileDetails.tsx
+++ b/src/components/Me/MeProfileDetails.tsx
@@ -3,11 +3,10 @@ import { Control, UseFormReset } from 'react-hook-form';
 import { Dispatch, SetStateAction } from 'react';
 import { MeChangeFields, MeData } from '@/types/me';
 import { Button, Input, notification } from 'antd';
-import { MdOutlineCancel } from 'react-icons/md';
+import { MdOutlineCancel, MdPerson } from 'react-icons/md';
 import { formatUserCreatedAt } from '@/utils/formatUserCreatedAt';
 import { UserFormInput } from '../Auth/UserFormInput';
-import { MdOutlineDateRange, MdOutlineAlternateEmail } from 'react-icons/md';
-import { MdOutlineAssignment } from 'react-icons/md';
+import { MdOutlineDateRange, MdOutlineAlternateEmail, MdOutlineAssignment } from 'react-icons/md';
 
 type Props = {
   control: Control<any>;
@@ -100,7 +99,8 @@ export const MeProfileDetails = ({
               accept="image/*"
               disabled={isUpdating}
               onChange={handleFileChange}
-              className="text-textPrimary file:cursor-pointer file:bg-transparent file:border-none file:text-textPrimary "
+              style={{ height: '35.81px' }}
+              className="text-textPrimary file:cursor-pointer file:bg-transparent file:border-none file:text-textPrimary py-1.5 px-4 rounded-lg"
             />
           </div>
           <UserFormInput
@@ -109,6 +109,7 @@ export const MeProfileDetails = ({
             label="Имя"
             name="firstName"
             placeholder="Имя"
+            prefix={<MdPerson size={20} className="mr-1" />}
             rules={UserFormValidationRules.name}
           />
           <UserFormInput
@@ -117,6 +118,7 @@ export const MeProfileDetails = ({
             name="lastName"
             placeholder="Фамилия"
             label="Фамилия"
+            prefix={<MdPerson size={20} className="mr-1" />}
             rules={UserFormValidationRules.surname}
           />
           <div className="flex flex-col gap-5 mb-6">

--- a/src/layouts/PageLayout.tsx
+++ b/src/layouts/PageLayout.tsx
@@ -145,8 +145,8 @@ export const PageLayout = ({ children }: { children?: ReactNode }) => {
         <div className="mt-5 flex-grow w-full max-w-screen-lg m-auto px-4">
           {children || <Outlet />}
         </div>
+        <Divider className="my-0 " />
         <footer className="py-4 z-50">
-          <Divider />
           <div className="justify-center flex text-textPrimary items-center px-2 text-xs lg:text-sm lg:px-0">
             © {new Date().getFullYear()} Все права защищены.
           </div>

--- a/src/pages/login/Page.tsx
+++ b/src/pages/login/Page.tsx
@@ -47,7 +47,7 @@ export const Login = () => {
 
   return (
     <ShapeWrapper>
-      <Content className="flex justify-center items-center min-h-screen overflow-y-auto">
+      <Content className="flex px-8 md:p-0 justify-center items-center min-h-screen overflow-y-auto">
         <GlassWrapper className="px-8 py-8 rounded-2xl max-w-sm w-full" style={{ zIndex: 10 }}>
           <div className="mb-6">
             <div className="flex justify-center mb-2">
@@ -100,16 +100,18 @@ export const Login = () => {
             <AuthSubmitButton disabled={isLoading} loading={isLoading}>
               Войти
             </AuthSubmitButton>
-            <AuthTextLink
-              text="Забыли пароль?"
-              linkText="Сбросить"
-              linkTo={ROUTES.RECOVERY_PASSWORD}
-            />
-            <AuthTextLink
-              text="Нет аккаунта?"
-              linkText="Зарегистрироваться"
-              linkTo={ROUTES.SIGNUP}
-            />
+            <div className="flex flex-col gap-0">
+              <AuthTextLink
+                text="Забыли пароль?"
+                linkText="Сбросить"
+                linkTo={ROUTES.RECOVERY_PASSWORD}
+              />
+              <AuthTextLink
+                text="Нет аккаунта?"
+                linkText="Зарегистрироваться"
+                linkTo={ROUTES.SIGNUP}
+              />
+            </div>
           </Form>
         </GlassWrapper>
       </Content>

--- a/src/pages/login/Page.tsx
+++ b/src/pages/login/Page.tsx
@@ -100,7 +100,7 @@ export const Login = () => {
             <AuthSubmitButton disabled={isLoading} loading={isLoading}>
               Войти
             </AuthSubmitButton>
-            <div className="flex flex-col gap-0">
+            <div>
               <AuthTextLink
                 text="Забыли пароль?"
                 linkText="Сбросить"

--- a/src/pages/login/Page.tsx
+++ b/src/pages/login/Page.tsx
@@ -77,6 +77,7 @@ export const Login = () => {
               control={control}
               name="email"
               placeholder="Email"
+              disabled={isLoading}
               rules={UserFormValidationRules.email}
               prefix={<MdMail size={20} className="mr-1" />}
             />
@@ -85,6 +86,7 @@ export const Login = () => {
               name="password"
               type={showPassword ? 'text' : 'password'}
               placeholder="Пароль"
+              disabled={isLoading}
               rules={UserFormValidationRules.password}
               prefix={<RiLockFill size={20} className="mr-1" />}
               suffix={

--- a/src/pages/me/Page.tsx
+++ b/src/pages/me/Page.tsx
@@ -80,14 +80,14 @@ export const Me = () => {
         setEdit(false);
       } catch (error) {
         notification.error({ message: 'Не удалось обновить данные' });
-        console.error('Ошибка обновления данных:', error);
+        console.log('Ошибка обновления данных:', error);
       }
     }
   };
 
   usePageTitle('Профиль');
 
-  if (isLoading || isUpdating) return <Loader />;
+  if (isLoading) return <Loader />;
 
   if (error || !user) {
     return (
@@ -123,16 +123,17 @@ export const Me = () => {
               avatar={avatar}
             />
             <MeProfileDetails
-              isEditing={isEdit}
+              isEdit={isEdit}
               control={control}
               reset={reset}
               user={user}
               setEdit={setEdit}
               setAvatar={setAvatar}
+              isUpdating={isUpdating}
             />
           </Form>
         </GlassWrapper>
-        <GlassWrapper className="w-1/3 px-5 min-w-80 py-5 text-center" style={{ zIndex: 10 }}>
+        <GlassWrapper className="w-1/3 px-5 py-5 min-w-80  text-center" style={{ zIndex: 10 }}>
           <MeChangePassword />
         </GlassWrapper>
       </Content>

--- a/src/pages/me/Page.tsx
+++ b/src/pages/me/Page.tsx
@@ -1,4 +1,5 @@
 import { MeAvatar, MeProfileActions, MeProfileDetails } from '@/components/Me';
+import { MeChangePassword } from '@/components/Me/MeChangePassword';
 import { Loader } from '@/components/ui/Loader';
 import { GlassWrapper } from '@/components/ui/wrapper/GlassWrapper';
 import { usePageTitle } from '@/hooks/usePageTitle';
@@ -6,13 +7,13 @@ import { useGetMeInfoQuery, useUpdateMeInfoMutation } from '@/redux/user';
 import { uploadToCloudinary } from '@/services/cloudinary.service';
 import { MeChangeFields } from '@/types/me';
 import { Alert, Form, notification } from 'antd';
+import { Content } from 'antd/es/layout/layout';
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 export const Me = () => {
   const [isEdit, setEdit] = useState<boolean>(false);
   const [avatar, setAvatar] = useState<File | null>(null);
-  const [isAlertVisible, setAlertVisible] = useState<boolean>(true);
   const [userUid, setUserUid] = useState(localStorage.getItem('user'));
 
   useEffect(() => {
@@ -45,7 +46,6 @@ export const Me = () => {
       reset({
         firstName: user?.firstName || '',
         lastName: user?.lastName || '',
-        email: user?.email || '',
       });
     }
   }, [user]);
@@ -77,7 +77,6 @@ export const Me = () => {
 
         notification.success({ message: 'Данные успешно обновлены' });
         setAvatar(null);
-        setAlertVisible(false);
         setEdit(false);
       } catch (error) {
         notification.error({ message: 'Не удалось обновить данные' });
@@ -88,62 +87,55 @@ export const Me = () => {
 
   usePageTitle('Профиль');
 
-  if (!user || isLoading || isUpdating) return <Loader />;
+  if (isLoading || isUpdating) return <Loader />;
+
+  if (error || !user) {
+    return (
+      <Alert
+        message="Ошибка"
+        description="Не удалось получить информацию о пользователе"
+        type="error"
+        showIcon
+      />
+    );
+  }
 
   return (
-    <div className="flex relative justify-center p-4 break-words w-full">
-      {isEdit && isAlertVisible && (
-        <div className="absolute top-[-10px] z-50">
-          <Alert
-            message="Для изменения аватара наведите на него и нажмите"
-            type="info"
-            showIcon
-            closable
-            onClose={() => setAlertVisible(false)}
-          />
-        </div>
-      )}
-      <GlassWrapper className="w-full md:w-1/2 px-5 py-5 text-center" style={{ zIndex: 10 }}>
-        {error ? (
-          <Alert
-            message="Ошибка загрузки данных"
-            description="Не удалось получить информацию о пользователе"
-            type="error"
-            showIcon
-          />
-        ) : (
-          <div className="">
-            <Form
-              onFinish={handleSubmit(onSubmit)}
-              className="w-full flex flex-col gap-4 text-center"
-            >
-              <MeProfileActions
-                isEdit={isEdit}
-                dirtyFields={dirtyFields}
-                isValid={isValid}
-                setEdit={setEdit}
-                isUpdating={isUpdating}
-                avatar={avatar}
-              />
-              <MeAvatar
-                currentAvatarUrl={user.avatarUrl}
-                isLoading={isLoading}
-                isEdit={isEdit}
-                setAvatar={setAvatar}
-                avatar={avatar}
-              />
-              <MeProfileDetails
-                isEditing={isEdit}
-                control={control}
-                reset={reset}
-                user={user}
-                setEdit={setEdit}
-                setAvatar={setAvatar}
-              />
-            </Form>
-          </div>
-        )}
-      </GlassWrapper>
+    <div className="flex p-4 break-words w-full">
+      <Content className="flex flex-col items-center md:flex-row gap-4 w-full md:items-start">
+        <GlassWrapper
+          className="w-full min-w-56 md:w-1/2 px-5 py-5 text-center"
+          style={{ zIndex: 10 }}
+        >
+          <Form onFinish={handleSubmit(onSubmit)}>
+            <MeProfileActions
+              isEdit={isEdit}
+              dirtyFields={dirtyFields}
+              isValid={isValid}
+              setEdit={setEdit}
+              isUpdating={isUpdating}
+              avatar={avatar}
+            />
+            <MeAvatar
+              currentAvatarUrl={user.avatarUrl}
+              isLoading={isLoading}
+              setAvatar={setAvatar}
+              avatar={avatar}
+            />
+            <MeProfileDetails
+              isEditing={isEdit}
+              control={control}
+              reset={reset}
+              user={user}
+              setEdit={setEdit}
+              setAvatar={setAvatar}
+            />
+          </Form>
+        </GlassWrapper>
+        <GlassWrapper className="w-1/3 px-5 min-w-56 py-5 text-center" style={{ zIndex: 10 }}>
+          <MeChangePassword />
+        </GlassWrapper>
+      </Content>
     </div>
   );
 };

--- a/src/pages/recoveryPassword/Page.tsx
+++ b/src/pages/recoveryPassword/Page.tsx
@@ -11,7 +11,7 @@ import { UserFormValidationRules } from '@/utils/validation';
 import { Form, notification, Typography } from 'antd';
 import { Content } from 'antd/es/layout/layout';
 import { SubmitHandler, useForm } from 'react-hook-form';
-import { MdMail } from 'react-icons/md';
+import { MdMail, MdLockReset } from 'react-icons/md';
 
 export const RecoveryPassword = () => {
   const { control, handleSubmit, reset } = useForm<EmailValue>({
@@ -33,9 +33,14 @@ export const RecoveryPassword = () => {
 
   return (
     <ShapeWrapper>
-      <Content className="flex justify-center items-center min-h-screen overflow-y-auto px-8">
+      <Content className="flex px-8 md:p-0 justify-center items-center min-h-screen overflow-y-auto">
         <GlassWrapper className="px-8 py-8 rounded-2xl max-w-sm w-full" style={{ zIndex: 10 }}>
           <div className="mb-6">
+            <div className="flex justify-center mb-2">
+              <div className="w-14 h-14 flex items-center justify-center bg-bgPrimary rounded-2xl shadow-lg">
+                <MdLockReset size={30} />
+              </div>
+            </div>
             <Typography.Title
               level={2}
               style={{

--- a/src/pages/recoveryPassword/Page.tsx
+++ b/src/pages/recoveryPassword/Page.tsx
@@ -62,6 +62,7 @@ export const RecoveryPassword = () => {
             <UserFormInput
               control={control}
               name="email"
+              disabled={isLoading}
               placeholder="Email"
               rules={UserFormValidationRules.email}
               prefix={<MdMail size={20} className="mr-1" />}

--- a/src/pages/signup/Page.tsx
+++ b/src/pages/signup/Page.tsx
@@ -50,7 +50,7 @@ export const Signup = () => {
 
   return (
     <ShapeWrapper>
-      <Content className="flex justify-center items-center min-h-screen overflow-y-auto px-8">
+      <Content className="flex px-8 md:p-0 justify-center items-center min-h-screen overflow-y-auto">
         <GlassWrapper className="px-8 py-8 rounded-2xl max-w-sm w-full" style={{ zIndex: 10 }}>
           <div className="mb-6">
             <div className="flex justify-center mb-2">
@@ -134,8 +134,8 @@ export const Signup = () => {
             <AuthSubmitButton disabled={isLoading} loading={isLoading}>
               Зарегистрироваться
             </AuthSubmitButton>
-            <div className="flex items-center justify-between">
-              <Form.Item className="flex justify-end mb-0">
+            <div className="flex justify-between mb-0 gap-1">
+              <Form.Item className="flex items-center justify-end">
                 <Button onClick={() => reset()} color="default" variant="solid">
                   Очистить форму
                 </Button>

--- a/src/pages/signup/Page.tsx
+++ b/src/pages/signup/Page.tsx
@@ -79,6 +79,7 @@ export const Signup = () => {
             <UserFormInput
               control={control}
               name="name"
+              disabled={isLoading}
               placeholder="Имя"
               rules={UserFormValidationRules.name}
               prefix={<MdPerson size={20} className="mr-1" />}
@@ -86,6 +87,7 @@ export const Signup = () => {
             <UserFormInput
               control={control}
               name="surname"
+              disabled={isLoading}
               placeholder="Фамилия"
               rules={UserFormValidationRules.surname}
               prefix={<MdPerson size={20} className="mr-1" />}
@@ -93,6 +95,7 @@ export const Signup = () => {
             <UserFormInput
               control={control}
               name="email"
+              disabled={isLoading}
               placeholder="Email"
               rules={UserFormValidationRules.email}
               prefix={<MdMail size={20} className="mr-1" />}
@@ -100,6 +103,7 @@ export const Signup = () => {
             <UserFormInput
               control={control}
               name="password"
+              disabled={isLoading}
               type={showPassword ? 'text' : 'password'}
               placeholder="Пароль"
               rules={UserFormValidationRules.password}
@@ -118,6 +122,7 @@ export const Signup = () => {
               control={control}
               name="copyPassword"
               type={showCopyPassword ? 'text' : 'password'}
+              disabled={isLoading}
               placeholder="Пароль"
               rules={UserFormValidationRules.copyPassword(password)}
               prefix={<RiLockFill size={20} className="mr-1" />}

--- a/src/redux/form/formApi.ts
+++ b/src/redux/form/formApi.ts
@@ -2,6 +2,8 @@ import { firestoreService } from '@/services/firestore.service';
 import { ConstructorForm, FormData } from '@/types';
 import { getFirebaseError } from '@/utils/firebase/getFirebaseError';
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { store } from '@/redux/store';
+import { userApi } from '../user/userApi';
 
 export const COLLECTION = 'form';
 
@@ -28,6 +30,7 @@ export const formApi = createApi({
         try {
           const userRef = await firestoreService.getRef('users', form.userId);
           const result = await firestoreService.create(COLLECTION, { ...form, userId: userRef });
+          store.dispatch(userApi.util.invalidateTags(['me']));
           return { data: result as FormData };
         } catch (error) {
           return { error: getFirebaseError(error) };
@@ -52,6 +55,7 @@ export const formApi = createApi({
       queryFn: async (id) => {
         try {
           const result = await firestoreService.delete(COLLECTION, id);
+          store.dispatch(userApi.util.invalidateTags(['me']));
           return { data: result };
         } catch (error) {
           return { error: getFirebaseError(error) };

--- a/src/redux/user/index.ts
+++ b/src/redux/user/index.ts
@@ -10,4 +10,4 @@ export const userQueryReducer = userApi.reducer;
 export const userReducerPath = userApi.reducerPath;
 export const userMiddleware = userApi.middleware;
 
-export const { useGetMeInfoQuery, useUpdateMeInfoMutation } = userApi;
+export const { useGetMeInfoQuery, useUpdateMeInfoMutation, useUpdatePasswordMutation } = userApi;

--- a/src/redux/user/userApi.ts
+++ b/src/redux/user/userApi.ts
@@ -34,6 +34,17 @@ export const userApi = createApi({
       },
       invalidatesTags: ['me'],
     }),
+
+    updatePassword: builder.mutation<void, { currentPassword: string; newPassword: string }>({
+      queryFn: async ({ currentPassword, newPassword }) => {
+        try {
+          await firestoreService.updateUserPassword(currentPassword, newPassword);
+          return { data: undefined };
+        } catch (error) {
+          return { error: getFirebaseError(error) };
+        }
+      },
+    }),
   }),
 });
 

--- a/src/services/firestore.service.ts
+++ b/src/services/firestore.service.ts
@@ -257,14 +257,12 @@ export const firestoreService = {
 
   updateUserPassword: async (currentPassword: string, newPassword: string): Promise<void> => {
     if (!auth.currentUser) {
-      throw new Error('Пользователь не авторизован');
+      return;
     }
 
     const user = auth.currentUser;
-
     const credential = EmailAuthProvider.credential(user.email!, currentPassword);
     await reauthenticateWithCredential(user, credential);
-
     await updatePassword(user, newPassword);
   },
 };

--- a/src/types/me.ts
+++ b/src/types/me.ts
@@ -7,6 +7,11 @@ export type MeData = {
   createdAt?: number;
   updatedAt?: number;
   avatarUrl?: string;
+  formsCount?: number;
 };
 
 export type MeChangeFields = Omit<MeData, 'uid' | 'id' | 'createdAt' | 'updatedAt'>;
+export type ChangePasswordFormValues = {
+  currentPassword: string;
+  newPassword: string;
+};

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -21,7 +21,7 @@ module.exports = {
         bgBase: 'var(--color-bg-base)',
       },
       spacing: {
-        'page-layout-offset': '93px',
+        'page-layout-offset': '138px',
       },
       keyframes: {
         opacityUp: {


### PR DESCRIPTION
* на странице me добавлено условие на всякий пожарный, что если данных по юзеру нету, то выводится ошибка Alert (ранее был бесконечный лоудер, я забывал поправить)

* добавил на странице me поле "Количество созданных форм" пользователем. С инвалидацией тега me в apiForm в createForm и в deleteForm

* убрал возможность менять свою почту, ибо с этим много геммора в firebase. А на деле я думаю вряд ли пользователи часто меняют свою почту в аккаунте на сайте. Если уж нужна другая почта, то проще новый акк зарегать. (да, статистика по созданным формам пропадет, но уж соррян)

* добавил возможность смены пароля на странице me
 
* немного изменил верстку на странице me при режиме обычного просмотра. И аватарка теперь меняется через  отдельное поле Input type = 'file', а не через сама аватарку

* убраны дефолтные стили auto-fill от браузера (они давали свои стили при автозаполнении при авторизации)