### PR TITLE
Fix/responses loading

### DIFF
--- a/src/components/FormResponses/TableResponses/TableResponses.tsx
+++ b/src/components/FormResponses/TableResponses/TableResponses.tsx
@@ -294,7 +294,7 @@ export const TableResponses = () => {
           dataSource={data}
           columns={columns}
           pagination={false}
-          scroll={{ x: 'max-content', y: 500 }}
+          scroll={{ x: 'max-content' }}
           loading={status === 'pending'}
           locale={{ emptyText: 'Ничего не найдено.' }}
           onRow={(data) => {

--- a/src/components/FormResponses/TableResponses/TableResponses.tsx
+++ b/src/components/FormResponses/TableResponses/TableResponses.tsx
@@ -153,6 +153,11 @@ export const TableResponses = () => {
       });
   };
 
+  // Не удалять. Необходим для сброса lastVisible в сторе
+  useEffect(() => {
+    resetLocalState();
+  }, []);
+
   const resetLocalState = () => {
     dispatch(resetStore());
     setHasNext(true);


### PR DESCRIPTION
1. Добавлен сброс lastVisible в responses store при заходе на страницу
2. Убран вертикальный скролл для верной работы inf scroll (как временное решение)